### PR TITLE
[skip ci] firestore.rulesを整備

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,9 +1,15 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if
-          request.time < timestamp.date(2021, 5, 6);
+    match /nature_log/{logID} {
+      allow read: if checkAuthentication();
+    }
+
+    function checkAuthentication() {
+      return request.auth != null &&
+        request.auth.token.email.matches('^(.+)@sukima[.]tech$') &&
+        request.auth.token.email_verified &&
+        request.auth.token.firebase.sign_in_provider == 'google.com';
     }
   }
 }


### PR DESCRIPTION
クライアントからは、認証されている場合にだけ読み込みのみ許可する